### PR TITLE
Update octave_ci.m

### DIFF
--- a/assets/ci/octave_ci.m
+++ b/assets/ci/octave_ci.m
@@ -69,7 +69,7 @@ function octave_ci (package_name, pkg_index_file)
   endif
 
   ## Install package dependencies and "doctest" package.
-  pkgs = [pkgs, {"doctest"}];
+  pkgs = [pkgs; {"doctest"}];
   for i = length (pkgs):-1:1
     pkg_dep_name = pkgs{i};
     pkg_dep_name_version = [pkg_dep_name, "@", ...


### PR DESCRIPTION
fix error related to horizontal mismatch when there are more than one dependencies